### PR TITLE
Add Support for Additional OBIS Codes and Data Fields

### DIFF
--- a/src/dsmr2/fields2.h
+++ b/src/dsmr2/fields2.h
@@ -497,3 +497,30 @@ DEFINE_FIELD(mbus4_delivered_dbl, TimestampedFixedValue, ObisId(0, 4, 24, 3, 0),
 } // namespace dsmr
 
 #endif // DSMR_INCLUDE_FIELDS_H
+
+/* Instantaneous active power import/export per phase */
+DEFINE_FIELD(instantaneous_active_power_import_l1, FixedValue, ObisId(1, 0, 21, 7, 0), FixedField, units::kW, units::W);
+DEFINE_FIELD(instantaneous_active_power_export_l1, FixedValue, ObisId(1, 0, 22, 7, 0), FixedField, units::kW, units::W);
+DEFINE_FIELD(instantaneous_active_power_import_l2, FixedValue, ObisId(1, 0, 41, 7, 0), FixedField, units::kW, units::W);
+DEFINE_FIELD(instantaneous_active_power_export_l2, FixedValue, ObisId(1, 0, 42, 7, 0), FixedField, units::kW, units::W);
+DEFINE_FIELD(instantaneous_active_power_import_l3, FixedValue, ObisId(1, 0, 61, 7, 0), FixedField, units::kW, units::W);
+DEFINE_FIELD(instantaneous_active_power_export_l3, FixedValue, ObisId(1, 0, 62, 7, 0), FixedField, units::kW, units::W);
+
+/* Instantaneous voltage per phase */
+DEFINE_FIELD(instantaneous_voltage_l1, FixedValue, ObisId(1, 0, 32, 7, 0), FixedField, units::V, units::V);
+DEFINE_FIELD(instantaneous_voltage_l2, FixedValue, ObisId(1, 0, 52, 7, 0), FixedField, units::V, units::V);
+DEFINE_FIELD(instantaneous_voltage_l3, FixedValue, ObisId(1, 0, 72, 7, 0), FixedField, units::V, units::V);
+
+/* Instantaneous reactive power import/export per phase */
+DEFINE_FIELD(instantaneous_reactive_power_import_l1, FixedValue, ObisId(1, 0, 23, 7, 0), FixedField, units::kvar, units::var);
+DEFINE_FIELD(instantaneous_reactive_power_export_l1, FixedValue, ObisId(1, 0, 24, 7, 0), FixedField, units::kvar, units::var);
+DEFINE_FIELD(instantaneous_reactive_power_import_l2, FixedValue, ObisId(1, 0, 43, 7, 0), FixedField, units::kvar, units::var);
+DEFINE_FIELD(instantaneous_reactive_power_export_l2, FixedValue, ObisId(1, 0, 44, 7, 0), FixedField, units::kvar, units::var);
+DEFINE_FIELD(instantaneous_reactive_power_import_l3, FixedValue, ObisId(1, 0, 63, 7, 0), FixedField, units::kvar, units::var);
+DEFINE_FIELD(instantaneous_reactive_power_export_l3, FixedValue, ObisId(1, 0, 64, 7, 0), FixedField, units::kvar, units::var);
+
+/* Energy data */
+DEFINE_FIELD(active_energy_import_total, FixedValue, ObisId(1, 0, 1, 8, 0), FixedField, units::kWh, units::Wh);
+DEFINE_FIELD(active_energy_export_total, FixedValue, ObisId(1, 0, 2, 8, 0), FixedField, units::kWh, units::Wh);
+DEFINE_FIELD(reactive_energy_import_total, FixedValue, ObisId(1, 0, 5, 8, 0), FixedField, units::kvarh, units::varh);
+DEFINE_FIELD(reactive_energy_export_total, FixedValue, ObisId(1, 0, 6, 8, 0), FixedField, units::kvarh, units::varh);

--- a/src/dsmr2/parser2.h
+++ b/src/dsmr2/parser2.h
@@ -479,3 +479,30 @@ struct P1Parser {
 } // namespace dsmr
 
 #endif // DSMR_INCLUDE_PARSER_H
+
+  // Instantaneous active power import/export per phase
+  PARSE_FIELD(instantaneous_active_power_import_l1);
+  PARSE_FIELD(instantaneous_active_power_export_l1);
+  PARSE_FIELD(instantaneous_active_power_import_l2);
+  PARSE_FIELD(instantaneous_active_power_export_l2);
+  PARSE_FIELD(instantaneous_active_power_import_l3);
+  PARSE_FIELD(instantaneous_active_power_export_l3);
+
+  // Instantaneous voltage per phase
+  PARSE_FIELD(instantaneous_voltage_l1);
+  PARSE_FIELD(instantaneous_voltage_l2);
+  PARSE_FIELD(instantaneous_voltage_l3);
+
+  // Instantaneous reactive power import/export per phase
+  PARSE_FIELD(instantaneous_reactive_power_import_l1);
+  PARSE_FIELD(instantaneous_reactive_power_export_l1);
+  PARSE_FIELD(instantaneous_reactive_power_import_l2);
+  PARSE_FIELD(instantaneous_reactive_power_export_l2);
+  PARSE_FIELD(instantaneous_reactive_power_import_l3);
+  PARSE_FIELD(instantaneous_reactive_power_export_l3);
+
+  // Energy data
+  PARSE_FIELD(active_energy_import_total);
+  PARSE_FIELD(active_energy_export_total);
+  PARSE_FIELD(reactive_energy_import_total);
+  PARSE_FIELD(reactive_energy_export_total);


### PR DESCRIPTION
This PR introduces support for additional OBIS codes and data fields as per the eMUCS-A1 specifications, aligning with the extended dataset needed for industrial AMR meters. The new OBIS codes have been added, and corresponding parsing logic has been implemented.
Key Additions:

    Instantaneous Active Power (per phase):
        Import/Export for phases L1, L2, L3 (OBIS: 1-0:21.7.0 to 1-0:62.7.0)
    Instantaneous Voltage (per phase):
        Voltage for phases L1, L2, L3 (OBIS: 1-0:32.7.0 to 1-0:72.7.0)
    Instantaneous Reactive Power (per phase):
        Import/Export for phases L1, L2, L3 (OBIS: 1-0:23.7.0 to 1-0:64.7.0)
    Energy Totals:
        Active Energy Import/Export (OBIS: 1-0:1.8.0, 1-0:2.8.0)
        Reactive Energy Import/Export (OBIS: 1-0:5.8.0, 1-0:6.8.0)

Modifications:

    fields2.h: Added definitions for new OBIS codes corresponding to instantaneous power, voltage, and energy totals.
    parser2.h: Updated parsing logic to handle the newly defined OBIS fields.

Testing:

    Unit tests should be updated or added to ensure that the new fields are parsed correctly from the P1 telegrams.